### PR TITLE
Document and update metadata widget usage

### DIFF
--- a/implementation_guide/create_your_first_ig.rst
+++ b/implementation_guide/create_your_first_ig.rst
@@ -98,7 +98,7 @@ The widget behaves as follows:
 
 - If no fields are specified, all non-empty fields are rendered in the default order defined by the FHIR specification.
 - If fields are specified, only those fields are rendered (when non-empty) in the order they were listed.
-- When the optional ``render-metadata-title`` flag is set, a title is also displayed containing the ``name`` of the resource.
+- When the optional ``render-metadata-title`` flag is set, a title is also displayed containing the ResourceType + ``name`` of the resource.
 
 
 Index

--- a/implementation_guide/create_your_first_ig.rst
+++ b/implementation_guide/create_your_first_ig.rst
@@ -76,11 +76,34 @@ After adding these statements in the editor refresh the page, by pressing Crtl +
 - ``{{namingsystems:ProjectName}}``				- lists all namespaces of a project in a table
 - ``{{render:canonicalUrl}}``                   - renders and parses any file type 
 - ``{{source:canonicalUrl}}``                   - renders any filetype unparsed. In case of a profile, it will render the xml or json, and for an FQL file, it will render the script text
-- ``{{metadata}}``                              - renders a consistent metadata table for the resource
+- ``{{metadata:canonicalUrl}}``                 - renders a consistent metadata table for the resource
 
-You can customize which metadata fields are included by listing them as attributes, for example: ``{{metadata, url, version, publisher}}``
+You can customize which metadata fields are included by listing them as attributes, for example: ``{{metadata:canonicalUrl, url, version, publisher}}``
 
-The following statements add an index within the IG. 
+Metadata fields
+"""""""""""""""
+The ``metadata`` widget renders a table of metadata fields for the referenced resource, for example:
+
+::
+
+    {{metadata:http://acme.org/StructureDefinition/profile-patient, render-metadata-title}}
+
+The supported fields depend on the resource type:
+
+- **Conformance resources**: ``url``, ``version``, ``publisher``, ``status``, ``experimental``, ``description``, ``purpose``, ``useContext``, ``contact``
+- **MessageDefinition**: ``title``, ``event``, ``category``
+- **StructureDefinition**: ``context`` (for extensions)
+
+The widget behaves as follows:
+
+- If no fields are specified, all non-empty fields are rendered in the default order defined by the FHIR specification.
+- If fields are specified, only those fields are rendered (when non-empty) in the order they were listed.
+- When the optional ``render-metadata-title`` flag is set, a title is also displayed containing the ``name`` of the resource.
+
+
+Index
+"""""
+The following statements add an index within the IG.
 
 - ``{{index:root}}``	- gives an index of the entire IG 
 - ``{{index:current}}`` - gives an index of the current selected element

--- a/implementation_guide/customize_your_ig.rst
+++ b/implementation_guide/customize_your_ig.rst
@@ -68,7 +68,7 @@ Consolidated Metadata Table in Implementation Guides
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 It's now easier to create a consistent table with all the metadata of resources within your Implementation Guides.
-Just use the new ``{{metadata}}`` widget and a consistent table will be shown with the resource metadata.
+Just use the new ``{{metadata:canonicalUrl}}`` widget and a consistent table will be shown with the resource metadata.
 
 .. note::
 
@@ -79,7 +79,7 @@ Just provide a list as the second attribute, for example:
 
 .. code-block:: text
 
-    {{metadata, url, version, publisher}}
+    {{metadata:canonicalUrl, url, version, publisher}}
 
 CSS-editor
 ^^^^^^^^^^


### PR DESCRIPTION
Update Implementation Guide docs to use the new metadata widget syntax and document its behavior. Changes: switch examples from `{{metadata}}` to `{{metadata:canonicalUrl}}`, add a detailed "Metadata fields" section with usage example, supported fields per resource type, and widget behavior (default vs. explicit fields and render-metadata-title flag). Also update corresponding examples in customize_your_ig.rst. Minor reformatting around the IG index section.